### PR TITLE
feature: support for unathenticated queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,28 @@ Retrieve the labels associated with a GitHub Pull Request and publish them as en
 
 Multiple labels will appear as comma-separated values.
 
-## Pre-requisites
+## Pre-requisites for private repositories
 
-A valid GitHub token (PAT) must be provided for this plugin to function. It can be provided either inside an environment variable or inside a file.
+When using with a private github repository, a valid GitHub token (PAT) must be provided.
+It can be provided either inside an environment variable or inside a file.
 Other plugins can be used before this plugin to set up the token.
 
 ## Examples
 
-### Publish the labels as environment variable
+### Publish the labels as environment variable (public repository)
+
+The comma-separated list of labels will be published in the `PULL_REQUEST_LABELS` environment variable.
+The variable is accessible to all subsequent commands and plugins within the same step.
+
+```yml
+steps:
+  - command: ls
+    plugins:
+      - sv-oss/github-pr-labels#v0.0.1:
+          publish-env-var: PULL_REQUEST_LABELS
+```
+
+### Publish the labels as environment variable (private repository)
 
 In this example a valid GitHub token has been pre-loaded inside the GITHUB_TOKEN environment variable
 
@@ -28,7 +42,7 @@ steps:
           publish-env-var: PULL_REQUEST_LABELS
 ```
 
-### Publish the labels as build meta-data
+### Publish the labels as build meta-data (private repository)
 
 In this example a valid GitHub token has been pre-loaded inside the /etc/github/token file
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -23,18 +23,21 @@ fi
 githubToken=""
 if [[ -n "${BUILDKITE_PLUGIN_GITHUB_PR_LABELS_TOKEN_FROM_FILE:-}" ]]; then
   echo "~~~ :clipboard: reading github token from file"
-  githubToken=$(< "${BUILDKITE_PLUGIN_GITHUB_PR_LABELS_TOKEN_FROM_FILE}")
+  githubToken=$(cat "${BUILDKITE_PLUGIN_GITHUB_PR_LABELS_TOKEN_FROM_FILE}")
 elif [[ -n "${BUILDKITE_PLUGIN_GITHUB_PR_LABELS_TOKEN_FROM_ENV:-}" ]]; then
   echo "~~~ :clipboard: reading github token from env var"
   githubToken="${!BUILDKITE_PLUGIN_GITHUB_PR_LABELS_TOKEN_FROM_ENV}"
 else
-  echo ":error: configuration is missing a valid 'token-from' stanza"
-  exit 3
+  echo ":warning: configuration is missing a valid 'token-from' stanza. requests to github will be unauthenticated"
 fi
 
 echo "~~~ :github: retrieving pull-request labels"
 jqFilter='[.labels[].name] | join(",")'
-labels=$(curl -f -Ss -H @- "https://api.github.com/repos/${repoFq}/pulls/${pullReqNo}" <<<"Authorization: Bearer ${githubToken}" | jq -r "$jqFilter" -)
+if [[ -z "${githubToken}" ]]; then
+  labels=$(curl -f -Ss "https://api.github.com/repos/${repoFq}/pulls/${pullReqNo}" | jq -r "$jqFilter" -)
+else
+  labels=$(curl -f -Ss -H @- "https://api.github.com/repos/${repoFq}/pulls/${pullReqNo}" <<<"Authorization: Bearer ${githubToken}" | jq -r "$jqFilter" -)
+fi
 
 echo "~~~ :github: labels for PR #${pullReqNo} are: ${labels}"
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -26,6 +26,4 @@ configuration:
       type: string
     publish-metadata-key:
       type: string
-  required:
-    - token-from
   additionalProperties: false


### PR DESCRIPTION
When using with public github repositories, there is no need for a github token. Support this scenario appropriately 